### PR TITLE
Update build tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.10.3
+      - image: golang:1.11.2
     working_directory: /go/src/github.com/lessor/lessor
     steps: &steps
       - checkout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,384 +2,462 @@
 
 
 [[projects]]
+  digest = "1:a639b30711f62030ade1432a6bcf135c23c38607d1478d3ce53829ea2a664197"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
-  version = "v0.21.0"
+  pruneopts = ""
+  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
+  version = "v0.34.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:22a800dff0d8932b39749e2196a33d27d82d2ae495db3960db55b23e68fb1efa"
   name = "dmitri.shuralyov.com/text/kebabcase"
   packages = ["."]
+  pruneopts = ""
   revision = "40e40b42552a9cb37d6e98f4ad31f63ae53ea43a"
 
 [[projects]]
+  digest = "1:c23e55bdd350c52d79d08aa293a1baae8cd450b31e6d36eab8034e119e3363dc"
   name = "github.com/aymerick/raymond"
   packages = [
     ".",
     "ast",
     "lexer",
-    "parser"
+    "parser",
   ]
+  pruneopts = ""
   revision = "2eebd0f5dd9564c0c6e439df11d8a3c7b9b9ab11"
   version = "v2.0.2"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = ""
+  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
+  version = "v4.1.0"
+
+[[projects]]
+  digest = "1:2defd14040b1ca18840524e9d0f9cfab0ea8d2f2d396b343d221f8bc8e21ab9d"
+  name = "github.com/fatih/structs"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4966fc68f5b7593aafa6cbbba2d65ec6e1416047"
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/fatih/structs"
-  packages = ["."]
-  revision = "a720dfa8df582c51dee1b36feabb906bde1588bd"
-  version = "v1.0"
-
-[[projects]]
-  name = "github.com/ghodss/yaml"
-  packages = ["."]
-  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
-  version = "v1.0.0"
-
-[[projects]]
+  digest = "1:48e65aaf8ce34ffb3e8d56daa9417826db162afbc2040705db331e9a2e9eebe3"
   name = "github.com/go-kit/kit"
   packages = [
     "log",
-    "log/level"
+    "log/level",
   ]
-  revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
-  version = "v0.6.0"
+  pruneopts = ""
+  revision = "12210fb6ace19e0496167bb3e667dcd91fa9f69b"
+  version = "v0.8.0"
 
 [[projects]]
+  digest = "1:df89444601379b2e1ee82bf8e6b72af9901cbeed4b469fa380a519c89c339310"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
-  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
-  version = "v0.3.0"
+  pruneopts = ""
+  revision = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc"
+  version = "v0.4.0"
 
 [[projects]]
-  name = "github.com/go-stack/stack"
-  packages = ["."]
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
-
-[[projects]]
+  digest = "1:b0989e1ceaa5fb28ad7dcb6f21da9386124942f24e5d8e5807f967f6f56ae2b0"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
-  revision = "ef60bfc50c8f92d1ee64674d8ce7a48f1f67625e"
-  version = "v1.6.2"
+  pruneopts = ""
+  revision = "801d7253ade1f895f74596b9a96147ed2d3b087e"
+  version = "v1.6.11"
 
 [[projects]]
+  branch = "master"
+  digest = "1:fc945bb5251cb058f9cdb3556f0f36598558fa282e42f8d431f5594b8dcff8b9"
+  name = "github.com/gobuffalo/flect"
+  packages = ["."]
+  pruneopts = ""
+  revision = "24a2b68e0316dd16128e820c3d60c89ed09911b0"
+
+[[projects]]
+  digest = "1:949389a861618f7ffd0c0ab92cc32631fc52487934272e2c5b57cc4d6d159689"
+  name = "github.com/gobuffalo/github_flavored_markdown"
+  packages = [
+    ".",
+    "internal/russross/blackfriday",
+    "internal/shurcooL/highlight_diff",
+    "internal/shurcooL/highlight_go",
+    "internal/shurcooL/octicon",
+    "internal/shurcooL/sanitized_anchor_name",
+  ]
+  pruneopts = ""
+  revision = "c57d0cf4d2cdde649ecc22f61c78cc9cd41e56af"
+  version = "v1.0.7"
+
+[[projects]]
+  digest = "1:50614eb9c3b6cf35e53694e125434d473a60e4a199c41d5fea31dff5d9ba34a6"
   name = "github.com/gobuffalo/plush"
   packages = [
     ".",
     "ast",
     "lexer",
     "parser",
-    "token"
+    "token",
   ]
-  revision = "2c66199a1b24507c54f4b9b478ead39890e86ff6"
-  version = "v3.7.1"
+  pruneopts = ""
+  revision = "df1620557a723b4c5efbd4af6a68c6640bfc0878"
+  version = "v3.7.32"
 
 [[projects]]
+  digest = "1:2785b601097ecb72188ff4932ff8f617f1c05a3f67eb27abf8ab438eae8fb979"
   name = "github.com/gobuffalo/tags"
   packages = [
     ".",
     "form",
-    "form/bootstrap"
+    "form/bootstrap",
   ]
-  revision = "82cd7696c84aba829b74e81814ff489b64e7b56a"
+  pruneopts = ""
+  revision = "5bface973eaf8938807a6d0c075c415911f45b48"
+  version = "v2.0.15"
+
+[[projects]]
+  digest = "1:4b6a43ba3296f26ea01ae125e50951f141c215dd18b5b91e9f397117b2951eb1"
+  name = "github.com/gobuffalo/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3f701655805f1ef76e9963d1b377497a0c66d7cd"
   version = "v2.0.5"
 
 [[projects]]
-  name = "github.com/gobuffalo/uuid"
-  packages = ["."]
-  revision = "3a9fb6c5c481d4886f1e9323c61ad743fb955860"
-  version = "v2.0.0"
-
-[[projects]]
+  digest = "1:034a8efb07cc78327b9203f3fb4863326745658e220eaab8ec9ae5f6b37a9c47"
   name = "github.com/gobuffalo/validate"
   packages = [
     ".",
-    "validators"
+    "validators",
   ]
-  revision = "42d8db6e06e617cdedcc7a849d6690a2cb5a8d28"
-  version = "v2.0.0"
+  pruneopts = ""
+  revision = "f6f3be4568c1ac31b364193100816d272e36ddc5"
+  version = "v2.0.3"
 
 [[projects]]
+  digest = "1:660175e70abad3868119f2c29f43339608d7d3b93c8eb178b812ed330be6c07b"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7077aa61129615a0d7f45c49101cd011ab221c27"
+  version = "v3.1.2"
+
+[[projects]]
+  digest = "1:527e1e468c5586ef2645d143e9f5fbd50b4fe5abc8b1e25d9f1c416d22d24895"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
+  digest = "1:aa2251148505e561bfa8cd6b69a319b37761da57b0b25529c4af08389559e3b9"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
-  revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
+  pruneopts = ""
+  revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
   name = "github.com/google/btree"
   packages = ["."]
-  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
+  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
-  revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
-  version = "v0.1.0"
+  pruneopts = ""
+  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e345eb75d8bfb2b91cfbfe02a82a79c0b2ea55cf06c5a4d180a9321f36973b4"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
-  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
+  pruneopts = ""
+  revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
 
 [[projects]]
-  branch = "master"
+  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+  pruneopts = ""
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
+  digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
-  version = "v0.3.4"
+  pruneopts = ""
+  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
+  version = "v0.3.6"
 
 [[projects]]
+  digest = "1:7df5a9695a743c3e1626b28bb8741602c8c15527e1efaeaec48ab2ff9a23f74c"
   name = "github.com/joho/godotenv"
   packages = ["."]
-  revision = "a79fa1e548e2c689c241d10173efd51e5d689d5b"
-  version = "v1.2.0"
+  pruneopts = ""
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
 
 [[projects]]
+  digest = "1:b79fc583e4dc7055ed86742e22164ac41bf8c0940722dbcb600f1a3ace1a8cb5"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+  pruneopts = ""
+  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
+  version = "v1.1.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:af395498c557bb6c1020758fc419e282a6b5c17b7125f4822658c69564a72f75"
   name = "github.com/kolide/kit"
   packages = [
     "env",
-    "logutil"
+    "logutil",
   ]
-  revision = "2905b8bccb710fd75f6608a46345d764cf58a047"
+  pruneopts = ""
+  revision = "bd1a9de64d4895c04a20084736aab1cd1fdbe8ab"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/markbates/going"
-  packages = [
-    "defaults",
-    "wait"
-  ]
-  revision = "0576708c56cea02331f864fe6e157ac7841923e4"
-
-[[projects]]
-  branch = "master"
+  digest = "1:68145053d55a0fa6b5f259eb70de75cb3914f6440472007e67c87894e1c06697"
   name = "github.com/markbates/inflect"
   packages = ["."]
-  revision = "fbc6b23ce49e2578f572d2e72bb72fa03c7145de"
+  pruneopts = ""
+  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
+  version = "v1.0.4"
 
 [[projects]]
-  branch = "master"
+  digest = "1:125f8ef0b7b53f42fe8d82b5462d803d56c2d357b8cea7796ed7cee0214008ec"
   name = "github.com/microcosm-cc/bluemonday"
   packages = ["."]
-  revision = "995366fdf961d03629cd17361bddd32745718e2c"
+  pruneopts = ""
+  revision = "82c7118e8ccf7403d4860175d97bb635e8e28239"
+  version = "v1.0.1"
 
 [[projects]]
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = ""
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
-  version = "1.0.0"
+  pruneopts = ""
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = ""
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = ""
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/russross/blackfriday"
-  packages = ["."]
-  revision = "11635eb403ff09dbc3a6b5a007ab5ab09151c229"
+  digest = "1:e47e8da3ae71a043c8ad101dea4e96580aaa613ff766150b799221e6c021508f"
+  name = "github.com/rogpeppe/go-internal"
+  packages = [
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = ""
+  revision = "d87f08a7d80821c797ffc8eb8f4e01675f378736"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2cca4fc02c8329dadfc6e831e6feb61845983b434fb3e8a034fe5753295a752d"
   name = "github.com/serenize/snaker"
   packages = ["."]
+  pruneopts = ""
   revision = "a683aaf2d516deecd70cad0c72e3ca773ecfcef0"
 
 [[projects]]
+  digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
+  pruneopts = ""
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  name = "github.com/shurcooL/github_flavored_markdown"
-  packages = ["."]
-  revision = "28433ea3fc83827d77424782fefdcd94703366cc"
-
-[[projects]]
-  branch = "master"
+  digest = "1:cb538699b6b1e9837d9944ad8465f3c2497e05c82a8155e84b682c35dd13a83a"
   name = "github.com/shurcooL/go"
   packages = [
     "parserutil",
     "printerutil",
     "reflectfind",
-    "reflectsource"
+    "reflectsource",
   ]
-  revision = "47fa5b7ceee66c60ac3a281416089035bf526a3c"
+  pruneopts = ""
+  revision = "914043390fc61e853638b3b18e1fdc33f01832ec"
 
 [[projects]]
   branch = "master"
+  digest = "1:0e98454221e57c75314270bfc426b4f6aa1c6b92e2a9f684f91daada477e80b1"
   name = "github.com/shurcooL/go-goon"
   packages = ["."]
+  pruneopts = ""
   revision = "37c2f522c041b74919a9e5e3a6c5c47eb34730a5"
 
 [[projects]]
   branch = "master"
+  digest = "1:d323a56ad143e37d767084a12ce2b861a30773527da8b5685ccd8714a3f522a9"
   name = "github.com/shurcooL/graphql"
   packages = ["ident"]
-  revision = "3d276b9dcc6b1e0adf19557a8de5cb8632c07697"
+  pruneopts = ""
+  revision = "16b88644589aaa174a21ae55cac72a9f60d5d837"
 
 [[projects]]
   branch = "master"
-  name = "github.com/shurcooL/highlight_diff"
-  packages = ["."]
-  revision = "09bb4053de1b1d872a9f25dc21378fa71dca4e4e"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/shurcooL/highlight_go"
-  packages = ["."]
-  revision = "78fb10f4a5f89e812a5e26ab723b954a51226086"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/shurcooL/octiconssvg"
-  packages = ["."]
-  revision = "91d14858bf8188ba5143d67a3a677ea559000b0a"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/shurcooL/sanitized_anchor_name"
-  packages = ["."]
-  revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
-
-[[projects]]
-  branch = "master"
+  digest = "1:2572a527898d3259bef02863f0c45a8500eed4b263daae03028693e36a66441e"
   name = "github.com/sourcegraph/annotate"
   packages = ["."]
+  pruneopts = ""
   revision = "f4cad6c6324d3f584e1743d8b3e0e017a5f3a636"
 
 [[projects]]
   branch = "master"
+  digest = "1:b2d735650965b30a58c303473b9ffb68f580674ddb06866848472d547f962b8f"
   name = "github.com/sourcegraph/syntaxhighlight"
   packages = ["."]
+  pruneopts = ""
   revision = "bd320f5d308e1a3c4314c678d8227a0d72574ae7"
 
 [[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
+  pruneopts = ""
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  pruneopts = ""
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
+  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:887074c37fcefc2f49b5ae9c6f9f36107341aec23185613d0e9f1ee81db7f94a"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "d6449816ce06963d9d136eee5a56fca5b0616e7e"
+  pruneopts = ""
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e21bd471bcad726f573e5e41b7eafe690a1724fdebac6e633d06b58b702d88d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -390,32 +468,37 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex"
   ]
-  revision = "d41e8174641f662c5a2d1c7a5f9e828788eb8706"
+  pruneopts = ""
+  revision = "891ebc4b82d6e74f468c533b06f983c7be918a96"
 
 [[projects]]
   branch = "master"
+  digest = "1:ea010cdb976f9de0c763728a76278f9109fca3299abd0dc3e8f2ccb9ff347268"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
-  revision = "6881fee410a5daf86371371f9ad451b95e168b71"
+  pruneopts = ""
+  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
 
 [[projects]]
   branch = "master"
+  digest = "1:c2c4c39f961dde3f317a48713db65329863b61316edabf19b96784b2da8406ac"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
-  revision = "b126b21c05a91c856b027c16779c12e3bf236954"
+  pruneopts = ""
+  revision = "4d1cda033e0619309c606fc686de3adcf599539e"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -431,28 +514,41 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:14cb1d4240bcbbf1386ae763957e04e2765ec4e4ce7bb2769d05fa6faccd774e"
   name = "golang.org/x/time"
   packages = ["rate"]
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  pruneopts = ""
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
+  digest = "1:a8d887c11cff791b28bf6a09877009222dd8b44f2df8ae7c65e0d1f09a8f6df4"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/cgo",
+    "go/internal/gcimporter",
+    "go/packages",
+    "go/types/typeutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/semver",
   ]
-  revision = "c65208ee29128450a4a024e3b7710f3a8d14028d"
+  pruneopts = ""
+  revision = "fe2443f7b95069e01d0b02159564c1b4d0dfcb5e"
 
 [[projects]]
+  digest = "1:77d3cff3a451d50be4b52db9c7766c0d8570ba47593f0c9dc72173adb208e788"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -464,25 +560,31 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
+  version = "v1.3.0"
 
 [[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  pruneopts = ""
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:4c9196e95e80a535cac4e8b5ddede652857b5c6c17070c8a484c553d2fc4e021"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -490,16 +592,19 @@
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
     "authorization/v1beta1",
     "autoscaling/v1",
     "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
     "batch/v1",
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
@@ -513,12 +618,14 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
-  revision = "ded72da34a273a447508135b315f865aa6e48fc8"
+  pruneopts = ""
+  revision = "d04500c8c3dda9c980b668c57abc2ca61efcf5c4"
 
 [[projects]]
-  branch = "release-1.11"
+  branch = "release-1.13"
+  digest = "1:66b0292f815d508d11ed5fe94fdeb0bcc5a988703a08e73bf3cb3a415de676cf"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -550,6 +657,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
+    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
@@ -561,11 +669,13 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
-  revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
+  pruneopts = ""
+  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 
 [[projects]]
+  digest = "1:96ab89894f66b77a0137bba12e607c6a9be992acadfb075b5602939e8519a157"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -578,15 +688,20 @@
     "informers/apps/v1",
     "informers/apps/v1beta1",
     "informers/apps/v1beta2",
+    "informers/auditregistration",
+    "informers/auditregistration/v1alpha1",
     "informers/autoscaling",
     "informers/autoscaling/v1",
     "informers/autoscaling/v2beta1",
+    "informers/autoscaling/v2beta2",
     "informers/batch",
     "informers/batch/v1",
     "informers/batch/v1beta1",
     "informers/batch/v2alpha1",
     "informers/certificates",
     "informers/certificates/v1beta1",
+    "informers/coordination",
+    "informers/coordination/v1beta1",
     "informers/core",
     "informers/core/v1",
     "informers/events",
@@ -618,16 +733,19 @@
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1beta1",
     "kubernetes/typed/authorization/v1",
     "kubernetes/typed/authorization/v1beta1",
     "kubernetes/typed/autoscaling/v1",
     "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta2",
     "kubernetes/typed/batch/v1",
     "kubernetes/typed/batch/v1beta1",
     "kubernetes/typed/batch/v2alpha1",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/extensions/v1beta1",
@@ -647,12 +765,15 @@
     "listers/apps/v1",
     "listers/apps/v1beta1",
     "listers/apps/v1beta2",
+    "listers/auditregistration/v1alpha1",
     "listers/autoscaling/v1",
     "listers/autoscaling/v2beta1",
+    "listers/autoscaling/v2beta2",
     "listers/batch/v1",
     "listers/batch/v1beta1",
     "listers/batch/v2alpha1",
     "listers/certificates/v1beta1",
+    "listers/coordination/v1beta1",
     "listers/core/v1",
     "listers/events/v1beta1",
     "listers/extensions/v1beta1",
@@ -696,13 +817,15 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
-  revision = "7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65"
-  version = "v8.0.0"
+  pruneopts = ""
+  revision = "e64494209f554a6723674bd494d69445fb76a1d4"
+  version = "v10.0.0"
 
 [[projects]]
-  branch = "release-1.11"
+  branch = "release-1.13"
+  digest = "1:d809e6c8dfa3448ae10f5624eff4ed1ebdc906755e7cea294c44e8b7ac0b077a"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -713,36 +836,100 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
-    "pkg/util"
+    "pkg/util",
   ]
-  revision = "6702109cc68eb6fe6350b83e14407c8d7309fd1a"
+  pruneopts = ""
+  revision = "c2090bec4d9b1fb25de3812f868accc2bc9ecbae"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0cc7d194e005097afad585545a3049ac7b5d1e3a1bfa86aa6bf6f2fb0e0a5063"
   name = "k8s.io/gengo"
   packages = [
     "args",
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
-  revision = "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+  pruneopts = ""
+  revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
+
+[[projects]]
+  digest = "1:4f5eb833037cc0ba0bf8fe9cae6be9df62c19dd1c869415275c708daa8ccfda5"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e5d4ca90c0f3862515c98454bb37d4d340f4ceeca60ac3e0a5cb5857360aed7c"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  revision = "f442ecb314a3679150c272e2b9713d8deed5955d"
+  pruneopts = ""
+  revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
   branch = "master"
+  digest = "1:415215d3e378ed2905a8437159a56b3700814928ab39fbd3e5051e3e4ec9c8c7"
   name = "k8s.io/sample-controller"
   packages = ["pkg/signals"]
-  revision = "119594ddec891a4a19381a3317d967a6b93a2b6e"
+  pruneopts = ""
+  revision = "65d042cac583e070fbed2e595decd273bc6d9528"
+
+[[projects]]
+  digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dc02bebba5f1327ef08daa2130f2bf41be174c2dc9edb1ba31d547127bf17529"
+  input-imports = [
+    "github.com/aymerick/raymond",
+    "github.com/go-kit/kit/log",
+    "github.com/go-kit/kit/log/level",
+    "github.com/gobuffalo/plush",
+    "github.com/kolide/kit/env",
+    "github.com/kolide/kit/logutil",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/require",
+    "github.com/urfave/cli",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/listers/apps/v1beta2",
+    "k8s.io/client-go/listers/core/v1",
+    "k8s.io/client-go/listers/policy/v1beta1",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/sample-controller/pkg/signals",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,26 +2,20 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[override]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.11"
+  branch = "release-1.13"
 
 [[override]]
   name = "k8s.io/apiserver"
-  branch = "release-1.11"
+  branch = "release-1.13"
 
 [[override]]
   name = "k8s.io/client-go"
-  version = "v8.0.0"
+  version = "v10.0.0"
 
 [[override]]
   name = "k8s.io/code-generator"
-  branch = "release-1.11"
-
-# vendor/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go:104:16:
-# unknown field 'CaseSensitive' in struct literal of type jsoniter.Config
-[[override]]
-  name = "github.com/json-iterator/go"
-  revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+  branch = "release-1.13"
 
 [[constraint]]
   name = "github.com/gobuffalo/plush"
-  version = "3.7.1"
+  version = "3.7.32"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+PATH := $(GOPATH)/bin:$(PATH)
+GO111MODULE=off
+
+all: build
+
+deps:
+	go get -u github.com/golang/dep/cmd/dep
+	dep ensure -vendor-only
+
+build:
+	go build .
+
+test:
+	go test -cover -race -v ./...
+
+generate:
+	./vendor/k8s.io/code-generator/generate-groups.sh all \
+		github.com/lessor/lessor/pkg/client \
+		github.com/lessor/lessor/pkg/apis \
+		lessor.io:v1 \
+		--go-header-file /dev/null

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -27,16 +27,10 @@ git clone git@github.com:lessor/lessor.git $GOPATH/src/github.com/lessor/lessor
 
 Lessor uses [Dep](https://github.com/golang/dep) to manage Go dependencies.
 
-To install the latest build of `dep`, run the following:
+To install the latest build of `dep` and download the project dependences, run:
 
 ```
-go get -u github.com/golang/dep/cmd/dep
-```
-
-To download the project dependences, run:
-
-```
-dep ensure -vendor-only
+make deps
 ```
 
 If you've added new code that requires on a new dependency, you must run the following for your dependency to be added:
@@ -52,10 +46,10 @@ If you'd like to update all dependencies, run `dep ensure -update`. If you'd lik
 Use `go build` to build the code:
 
 ```
-go build
+go build .
 ```
 
-This will produce a `lessor` binary in the root of the repository.
+You can also run `make` from the root of the repository to build the code. This will produce a `lessor` binary in the root of the repository.
 
 ```
 ./lessor --help
@@ -75,10 +69,10 @@ cp ./lessor /usr/local/bin/
 
 ## Test
 
-Use `go test` to run tests:
+To run tests, use the following command:
 
 ```
-go test -cover -race -v ./...
+make test
 ```
 
 ### Running a CI Build Locally
@@ -139,11 +133,7 @@ docker run -it gcr.io/lessor-io/lessor lessor --help
 To generate the [clientset](https://github.com/kubernetes/community/blob/master/contributors/devel/generating-clientset.md) for the Lessor API types, run the following:
 
 ```
-./vendor/k8s.io/code-generator/generate-groups.sh all \
-  github.com/lessor/lessor/pkg/client \
-  github.com/lessor/lessor/pkg/apis \
-  lessor.io:v1 \
-  --go-header-file /dev/null
+make generate
 ```
 
 ### Import Organization

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -8,15 +8,14 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 var parameterCodec = runtime.NewParameterCodec(scheme)
-
-func init() {
-	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	lessorv1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -29,10 +28,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	lessorv1.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -8,15 +8,14 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
-
-func init() {
-	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(Scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	lessorv1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -29,10 +28,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	lessorv1.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/pkg/client/clientset/versioned/typed/lessor.io/v1/fake/fake_tenant.go
+++ b/pkg/client/clientset/versioned/typed/lessor.io/v1/fake/fake_tenant.go
@@ -3,7 +3,7 @@
 package fake
 
 import (
-	lessor_io_v1 "github.com/lessor/lessor/pkg/apis/lessor.io/v1"
+	lessoriov1 "github.com/lessor/lessor/pkg/apis/lessor.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -23,20 +23,20 @@ var tenantsResource = schema.GroupVersionResource{Group: "lessor.io", Version: "
 var tenantsKind = schema.GroupVersionKind{Group: "lessor.io", Version: "v1", Kind: "Tenant"}
 
 // Get takes name of the tenant, and returns the corresponding tenant object, and an error if there is any.
-func (c *FakeTenants) Get(name string, options v1.GetOptions) (result *lessor_io_v1.Tenant, err error) {
+func (c *FakeTenants) Get(name string, options v1.GetOptions) (result *lessoriov1.Tenant, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(tenantsResource, c.ns, name), &lessor_io_v1.Tenant{})
+		Invokes(testing.NewGetAction(tenantsResource, c.ns, name), &lessoriov1.Tenant{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*lessor_io_v1.Tenant), err
+	return obj.(*lessoriov1.Tenant), err
 }
 
 // List takes label and field selectors, and returns the list of Tenants that match those selectors.
-func (c *FakeTenants) List(opts v1.ListOptions) (result *lessor_io_v1.TenantList, err error) {
+func (c *FakeTenants) List(opts v1.ListOptions) (result *lessoriov1.TenantList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(tenantsResource, tenantsKind, c.ns, opts), &lessor_io_v1.TenantList{})
+		Invokes(testing.NewListAction(tenantsResource, tenantsKind, c.ns, opts), &lessoriov1.TenantList{})
 
 	if obj == nil {
 		return nil, err
@@ -46,8 +46,8 @@ func (c *FakeTenants) List(opts v1.ListOptions) (result *lessor_io_v1.TenantList
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &lessor_io_v1.TenantList{ListMeta: obj.(*lessor_io_v1.TenantList).ListMeta}
-	for _, item := range obj.(*lessor_io_v1.TenantList).Items {
+	list := &lessoriov1.TenantList{ListMeta: obj.(*lessoriov1.TenantList).ListMeta}
+	for _, item := range obj.(*lessoriov1.TenantList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -63,31 +63,31 @@ func (c *FakeTenants) Watch(opts v1.ListOptions) (watch.Interface, error) {
 }
 
 // Create takes the representation of a tenant and creates it.  Returns the server's representation of the tenant, and an error, if there is any.
-func (c *FakeTenants) Create(tenant *lessor_io_v1.Tenant) (result *lessor_io_v1.Tenant, err error) {
+func (c *FakeTenants) Create(tenant *lessoriov1.Tenant) (result *lessoriov1.Tenant, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(tenantsResource, c.ns, tenant), &lessor_io_v1.Tenant{})
+		Invokes(testing.NewCreateAction(tenantsResource, c.ns, tenant), &lessoriov1.Tenant{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*lessor_io_v1.Tenant), err
+	return obj.(*lessoriov1.Tenant), err
 }
 
 // Update takes the representation of a tenant and updates it. Returns the server's representation of the tenant, and an error, if there is any.
-func (c *FakeTenants) Update(tenant *lessor_io_v1.Tenant) (result *lessor_io_v1.Tenant, err error) {
+func (c *FakeTenants) Update(tenant *lessoriov1.Tenant) (result *lessoriov1.Tenant, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(tenantsResource, c.ns, tenant), &lessor_io_v1.Tenant{})
+		Invokes(testing.NewUpdateAction(tenantsResource, c.ns, tenant), &lessoriov1.Tenant{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*lessor_io_v1.Tenant), err
+	return obj.(*lessoriov1.Tenant), err
 }
 
 // Delete takes name of the tenant and deletes it. Returns an error if one occurs.
 func (c *FakeTenants) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tenantsResource, c.ns, name), &lessor_io_v1.Tenant{})
+		Invokes(testing.NewDeleteAction(tenantsResource, c.ns, name), &lessoriov1.Tenant{})
 
 	return err
 }
@@ -96,17 +96,17 @@ func (c *FakeTenants) Delete(name string, options *v1.DeleteOptions) error {
 func (c *FakeTenants) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(tenantsResource, c.ns, listOptions)
 
-	_, err := c.Fake.Invokes(action, &lessor_io_v1.TenantList{})
+	_, err := c.Fake.Invokes(action, &lessoriov1.TenantList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched tenant.
-func (c *FakeTenants) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *lessor_io_v1.Tenant, err error) {
+func (c *FakeTenants) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *lessoriov1.Tenant, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(tenantsResource, c.ns, name, data, subresources...), &lessor_io_v1.Tenant{})
+		Invokes(testing.NewPatchSubresourceAction(tenantsResource, c.ns, name, pt, data, subresources...), &lessoriov1.Tenant{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*lessor_io_v1.Tenant), err
+	return obj.(*lessoriov1.Tenant), err
 }

--- a/pkg/client/clientset/versioned/typed/lessor.io/v1/tenant.go
+++ b/pkg/client/clientset/versioned/typed/lessor.io/v1/tenant.go
@@ -3,9 +3,11 @@
 package v1
 
 import (
+	"time"
+
 	v1 "github.com/lessor/lessor/pkg/apis/lessor.io/v1"
 	scheme "github.com/lessor/lessor/pkg/client/clientset/versioned/scheme"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -21,11 +23,11 @@ type TenantsGetter interface {
 type TenantInterface interface {
 	Create(*v1.Tenant) (*v1.Tenant, error)
 	Update(*v1.Tenant) (*v1.Tenant, error)
-	Delete(name string, options *meta_v1.DeleteOptions) error
-	DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
-	Get(name string, options meta_v1.GetOptions) (*v1.Tenant, error)
-	List(opts meta_v1.ListOptions) (*v1.TenantList, error)
-	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions) (*v1.Tenant, error)
+	List(opts metav1.ListOptions) (*v1.TenantList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Tenant, err error)
 	TenantExpansion
 }
@@ -45,7 +47,7 @@ func newTenants(c *LessorV1Client, namespace string) *tenants {
 }
 
 // Get takes name of the tenant, and returns the corresponding tenant object, and an error if there is any.
-func (c *tenants) Get(name string, options meta_v1.GetOptions) (result *v1.Tenant, err error) {
+func (c *tenants) Get(name string, options metav1.GetOptions) (result *v1.Tenant, err error) {
 	result = &v1.Tenant{}
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -58,24 +60,34 @@ func (c *tenants) Get(name string, options meta_v1.GetOptions) (result *v1.Tenan
 }
 
 // List takes label and field selectors, and returns the list of Tenants that match those selectors.
-func (c *tenants) List(opts meta_v1.ListOptions) (result *v1.TenantList, err error) {
+func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1.TenantList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("tenants").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested tenants.
-func (c *tenants) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *tenants) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("tenants").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -105,7 +117,7 @@ func (c *tenants) Update(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 }
 
 // Delete takes name of the tenant and deletes it. Returns an error if one occurs.
-func (c *tenants) Delete(name string, options *meta_v1.DeleteOptions) error {
+func (c *tenants) Delete(name string, options *metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("tenants").
@@ -116,11 +128,16 @@ func (c *tenants) Delete(name string, options *meta_v1.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *tenants) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+func (c *tenants) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("tenants").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -9,7 +9,7 @@ import (
 
 	versioned "github.com/lessor/lessor/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/lessor/lessor/pkg/client/informers/externalversions/internalinterfaces"
-	lessor_io "github.com/lessor/lessor/pkg/client/informers/externalversions/lessor.io"
+	lessorio "github.com/lessor/lessor/pkg/client/informers/externalversions/lessor.io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -156,9 +156,9 @@ type SharedInformerFactory interface {
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
-	Lessor() lessor_io.Interface
+	Lessor() lessorio.Interface
 }
 
-func (f *sharedInformerFactory) Lessor() lessor_io.Interface {
-	return lessor_io.New(f, f.namespace, f.tweakListOptions)
+func (f *sharedInformerFactory) Lessor() lessorio.Interface {
+	return lessorio.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -11,6 +11,7 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.
 type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
@@ -19,4 +20,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 
+// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
 type TweakListOptionsFunc func(*v1.ListOptions)

--- a/pkg/client/informers/externalversions/lessor.io/v1/tenant.go
+++ b/pkg/client/informers/externalversions/lessor.io/v1/tenant.go
@@ -5,11 +5,11 @@ package v1
 import (
 	time "time"
 
-	lessor_io_v1 "github.com/lessor/lessor/pkg/apis/lessor.io/v1"
+	lessoriov1 "github.com/lessor/lessor/pkg/apis/lessor.io/v1"
 	versioned "github.com/lessor/lessor/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/lessor/lessor/pkg/client/informers/externalversions/internalinterfaces"
 	v1 "github.com/lessor/lessor/pkg/client/listers/lessor.io/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
@@ -41,20 +41,20 @@ func NewTenantInformer(client versioned.Interface, namespace string, resyncPerio
 func NewFilteredTenantInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
 				return client.LessorV1().Tenants(namespace).List(options)
 			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
 				return client.LessorV1().Tenants(namespace).Watch(options)
 			},
 		},
-		&lessor_io_v1.Tenant{},
+		&lessoriov1.Tenant{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *tenantInformer) defaultInformer(client versioned.Interface, resyncPerio
 }
 
 func (f *tenantInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&lessor_io_v1.Tenant{}, f.defaultInformer)
+	return f.factory.InformerFor(&lessoriov1.Tenant{}, f.defaultInformer)
 }
 
 func (f *tenantInformer) Lister() v1.TenantLister {


### PR DESCRIPTION
This PR:

- updates the Go dependencies to track the 1.13 release branches
- adds a Makefile to make it easier to not use Go modules
- updates the developer guide to reference new make commands
- updates the version of Go used in CI