### PR TITLE
Lint the cmd directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint:
 	--enable=misspell \
 	--skip=client \
 	--skip=apis \
-	./pkg/...
+	./pkg/... ./cmd/...
 
 generate: clientset manifest
 


### PR DESCRIPTION
This PR lints `./cmd/...` in addition to `./pkg/...`